### PR TITLE
Add basic prerelease formula for up

### DIFF
--- a/Formulae/up.rb
+++ b/Formulae/up.rb
@@ -1,0 +1,32 @@
+class Up < Formula
+    desc "The official Upbound CLI"
+    homepage "https://upbound.io"
+    version "v0.0.0-142.g1307087"
+    license "Upbound Software License"
+    bottle :unneeded
+  
+    # TODO(hasheddan): add sha256 digests for bundles for first stable release
+    if OS.mac? && Hardware::CPU.intel?
+      url "https://cli.upbound.io/main/v0.0.0-142.g1307087/bundle/darwin_amd64.tar.gz"
+    end
+    if OS.mac? && Hardware::CPU.arm?
+      url "https://cli.upbound.io/main/v0.0.0-142.g1307087/bundle/darwin_arm64.tar.gz"
+    end
+    if OS.linux? && Hardware::CPU.intel?
+      url "https://cli.upbound.io/main/v0.0.0-142.g1307087/bundle/linux_amd64.tar.gz"
+    end
+    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+      url "https://cli.upbound.io/main/v0.0.0-142.g1307087/bundle/darwin_arm.tar.gz"
+    end
+    if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://cli.upbound.io/main/v0.0.0-142.g1307087/bundle/darwin_arm64.tar.gz"
+    end
+  
+    def install
+      bin.install "up"
+    end
+  
+    test do
+      system "#{bin}/up -v"
+    end
+  end


### PR DESCRIPTION
Adds a formula for install up with homebrew.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

This is loosely based off the [examples from goreleaser](https://goreleaser.com/customization/homebrew/), but I am not sure if homebrew is going to like me pointing directly at a binary here instead of a bottle tarball.