### PR TITLE
Add docker-credential-up and update  up to v0.11.0

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -1,0 +1,49 @@
+# Copyright 2022 Upbound Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class DockerCredentialUp < Formula
+    desc "Upbound Docker credential helper"
+    homepage "https://upbound.io"
+    version "v0.11.0"
+    license "Upbound Software License"
+  
+    if OS.mac? && Hardware::CPU.intel?
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/docker-credential-up/darwin_amd64.tar.gz"
+      sha256 "9b75ec19421c8ab9fcec4b26877ba95ffaf4172041339daaa8535b647619cf6d"
+    end
+    if OS.mac? && Hardware::CPU.arm?
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/docker-credential-up/darwin_arm64.tar.gz"
+      sha256 "59a52a76214d6c954d6bcd34fc6d97493ff1d83e5171e1edef921f88b48f28f7"
+    end
+    if OS.linux? && Hardware::CPU.intel?
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/docker-credential-up/linux_amd64.tar.gz"
+      sha256 "5f058752e64a488c6ae25e79e67628acc37d935ade887c41bef102e49178d025"
+    end
+    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/docker-credential-up/linux_arm.tar.gz"
+      sha256 "cbdcf846035343419689a55d76fa4df156c56d08758347111238af8c262fcc0a"
+    end
+    if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/docker-credential-up/linux_arm64.tar.gz"
+      sha256 "0a8f9db6991fff354b16c0c93bc4024397be75794253211aa11198dc32926495"
+    end
+  
+    def install
+      bin.install "docker-credential-up"
+    end
+  
+    test do
+      system "#{bin}/docker-credential-up -v"
+    end
+  end

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -1,4 +1,4 @@
-# Copyright 2021 Upbound Inc
+# Copyright 2022 Upbound Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,28 +15,28 @@
 class Up < Formula
     desc "The official Upbound CLI"
     homepage "https://upbound.io"
-    version "v0.10.0"
+    version "v0.11.0"
     license "Upbound Software License"
   
     if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.10.0/bundle/darwin_amd64.tar.gz"
-      sha256 "4686503b87b6a2a62d7a40172045031cd8bd8fccc6543568ed6ae4bcd14e6e25"
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/up/darwin_amd64.tar.gz"
+      sha256 "329adb068d0d5807f3ed6864533fa78527545c0ab0dd6f0f430b20f13d145f7a"
     end
     if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.10.0/bundle/darwin_arm64.tar.gz"
-      sha256 "cdd2d45b24d374ecb68452ed7aa58fc2ec4e28827a2e7513b28b5c222c5c6954"
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/up/darwin_arm64.tar.gz"
+      sha256 "39f44ec6e7be8a8dc99ab81d546d376ab5517d8115735791ea487a90ff2c074a"
     end
     if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.10.0/bundle/linux_amd64.tar.gz"
-      sha256 "2d1a9c2b0c5ecbcc76fd242453cf235548ea835e02c962c6fb37de91e27eceda"
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/up/linux_amd64.tar.gz"
+      sha256 "a45fb73624d1ba6ad6e45d772061152c254f1766cffdf34f407656fc962babd7"
     end
     if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.10.0/bundle/linux_arm.tar.gz"
-      sha256 "eaca79316f163bbdd086d93d2bd5c3de5682a7357ecf1c7c49d782b3b6308f31"
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/up/linux_arm.tar.gz"
+      sha256 "e6e5e556ed9a15a5deb6c8cab0ffd472572678eee07c4f6fa37a13e1b646707f"
     end
     if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.10.0/bundle/linux_arm64.tar.gz"
-      sha256 "d8d1bf4945ec01e34775674f074ff34a60caf48f92c8a05ec62423adf001c3b5"
+      url "https://cli.upbound.io/stable/v0.11.0/bundle/up/linux_arm64.tar.gz"
+      sha256 "5762be0cf3bd05ded0b5c98b54a4737cddaa4886425b93a0b4243aafb3743604"
     end
   
     def install


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a docker-credential-up Formula, which is starting at v0.11.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates up to v0.11.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested local install and verified correct version emitted with `<bin> -v`.