### PR TITLE
Update `up` and `docker-credential-up` to v0.12.1

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -15,28 +15,28 @@
 class DockerCredentialUp < Formula
     desc "Upbound Docker credential helper"
     homepage "https://upbound.io"
-    version "v0.12.0"
+    version "v0.12.1"
     license "Upbound Software License"
   
     if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/docker-credential-up/darwin_amd64.tar.gz"
-      sha256 "1c7b3452b683a39b93672af27203371041e1d778f31749c1880bc9810229253f"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/darwin_amd64.tar.gz"
+      sha256 "e746eb13ea4ef84d46c3aef88f2c2a03ae892208bd4e2b29b78ddf9d6fdecc2c"
     end
     if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/docker-credential-up/darwin_arm64.tar.gz"
-      sha256 "1627da3d005a1f131d719ca1606617a7f2b899f5759c151fe10cb0e77d7bb344"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/darwin_arm64.tar.gz"
+      sha256 "3fb01807f8c414a467d3fe9c65686b2103002e50930f6e678644db411f82dbb7"
     end
     if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/docker-credential-up/linux_amd64.tar.gz"
-      sha256 "a45dfe511fc88a6ea3cacf498cf7b027ae2c3d5c880edc672f9f282fa5044008"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/linux_amd64.tar.gz"
+      sha256 "6fb929ef6fc345f23f98dc61583c2df5b581cdba39680dc83e57ec44eee2b4c1"
     end
     if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/docker-credential-up/linux_arm.tar.gz"
-      sha256 "c862d97acc7cde4ff613ec1e167decc5e67e7c716ca0a84cb4f06ef02a777e79"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/linux_arm.tar.gz"
+      sha256 "62b902e4fa3cc25e60cb2315744ae0d9a6db27b047ddbb73310613c1bfcbd92e"
     end
     if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/docker-credential-up/linux_arm64.tar.gz"
-      sha256 "c4545bfe1cf7177dbc9dd0e4042da43d3c81f1dd6a4b8ac45281a2d984b90031"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/linux_arm64.tar.gz"
+      sha256 "00cec226d1bad1407b7aa257d49c7732977df08d028b21347b80340d5b9457e5"
     end
   
     def install

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -15,28 +15,28 @@
 class Up < Formula
     desc "The official Upbound CLI"
     homepage "https://upbound.io"
-    version "v0.12.0"
+    version "v0.12.1"
     license "Upbound Software License"
   
     if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/up/darwin_amd64.tar.gz"
-      sha256 "46ad432d4529f15325c6ae593f46dcce2b5efabebd88630faa2afe5b8e89cc7a"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/darwin_amd64.tar.gz"
+      sha256 "9e3a7d0c8a906a30a3821d7667d90f67685c7efc01e9db7b3b2dd782fee52fbc"
     end
     if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/up/darwin_arm64.tar.gz"
-      sha256 "e3d69cf59be428dfb215d7a996a6550d241af112bbdb3226161d09cc2469f2bd"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/darwin_arm64.tar.gz"
+      sha256 "3d2a3c2d4bc897d948e92da2cc52bc243ef6b8217021b67c6094d30a7f2f2515"
     end
     if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/up/linux_amd64.tar.gz"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/linux_amd64.tar.gz"
       sha256 "fa9817753a131f6b9f8c3be77c0c6f5b35e01925052b68ea32e64c88f0399db2"
     end
     if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/up/linux_arm.tar.gz"
-      sha256 "8019a4ed7d702e6b02c66ae30e4fc18c1a1cb8046ba3f38490a7c8d651c434e8"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/linux_arm.tar.gz"
+      sha256 "3d85466fa4e39ccb0a224690c061e69d207531cc23aa1a1696ac7880bf4b198c"
     end
     if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.0/bundle/up/linux_arm64.tar.gz"
-      sha256 "21f69883b6f12b0aca618c6811779bfe1b52299ac3f9ae8bd587fdaee0c904a2"
+      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/linux_arm64.tar.gz"
+      sha256 "abb980283399b1f5c1567f75cfc00447caf7fa7973a2c027b8bf3bdd19c58d34"
     end
   
     def install


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates docker-credential-up formula to v0.12.1.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates up formula to v0.12.1.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified local installs.