### PR TITLE
Update `up` and `docker-credential-up` to` v0.12.2`

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -15,28 +15,28 @@
 class DockerCredentialUp < Formula
     desc "Upbound Docker credential helper"
     homepage "https://upbound.io"
-    version "v0.12.1"
+    version "v0.12.2"
     license "Upbound Software License"
   
     if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/darwin_amd64.tar.gz"
-      sha256 "e746eb13ea4ef84d46c3aef88f2c2a03ae892208bd4e2b29b78ddf9d6fdecc2c"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_amd64.tar.gz"
+      sha256 "856f8d9fee3267d8857aed6da29b3890a2f8a9f4e13da4d225a4bcccb490583a"
     end
     if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/darwin_arm64.tar.gz"
-      sha256 "3fb01807f8c414a467d3fe9c65686b2103002e50930f6e678644db411f82dbb7"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_arm64.tar.gz"
+      sha256 "4c4851417c21b5ce0f90b7eceda617a0cfa17865a7fe00375b41fbd5326f2da5"
     end
     if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/linux_amd64.tar.gz"
-      sha256 "6fb929ef6fc345f23f98dc61583c2df5b581cdba39680dc83e57ec44eee2b4c1"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_amd64.tar.gz"
+      sha256 "af0eebbb44837bb61a1641cb5140eff1980b7f729a2414619071ea046bf17f92"
     end
     if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/linux_arm.tar.gz"
-      sha256 "62b902e4fa3cc25e60cb2315744ae0d9a6db27b047ddbb73310613c1bfcbd92e"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm.tar.gz"
+      sha256 "50b4aa8bec48818eceb93d395a5824583494b543eec4e278f8bf98528d78935c"
     end
     if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/docker-credential-up/linux_arm64.tar.gz"
-      sha256 "00cec226d1bad1407b7aa257d49c7732977df08d028b21347b80340d5b9457e5"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm64.tar.gz"
+      sha256 "0f389f38bdf2b28aaa8f9472a05ad0f4ca419ef9d5190c8945e24325fd6ffd47"
     end
   
     def install

--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2022 Upbound Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,37 +15,37 @@
 # limitations under the License.
 
 class DockerCredentialUp < Formula
-    desc "Upbound Docker credential helper"
-    homepage "https://upbound.io"
-    version "v0.12.2"
-    license "Upbound Software License"
-  
-    if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_amd64.tar.gz"
-      sha256 "856f8d9fee3267d8857aed6da29b3890a2f8a9f4e13da4d225a4bcccb490583a"
-    end
-    if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_arm64.tar.gz"
-      sha256 "4c4851417c21b5ce0f90b7eceda617a0cfa17865a7fe00375b41fbd5326f2da5"
-    end
-    if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_amd64.tar.gz"
-      sha256 "af0eebbb44837bb61a1641cb5140eff1980b7f729a2414619071ea046bf17f92"
-    end
-    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm.tar.gz"
-      sha256 "50b4aa8bec48818eceb93d395a5824583494b543eec4e278f8bf98528d78935c"
-    end
-    if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm64.tar.gz"
-      sha256 "0f389f38bdf2b28aaa8f9472a05ad0f4ca419ef9d5190c8945e24325fd6ffd47"
-    end
-  
-    def install
-      bin.install "docker-credential-up"
-    end
-  
-    test do
-      system "#{bin}/docker-credential-up -v"
-    end
+  desc 'Upbound Docker credential helper'
+  homepage 'https://upbound.io'
+  version 'v0.12.2'
+  license 'Upbound Software License'
+
+  if OS.mac? && Hardware::CPU.intel?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_amd64.tar.gz'
+    sha256 '856f8d9fee3267d8857aed6da29b3890a2f8a9f4e13da4d225a4bcccb490583a'
   end
+  if OS.mac? && Hardware::CPU.arm?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_arm64.tar.gz'
+    sha256 '4c4851417c21b5ce0f90b7eceda617a0cfa17865a7fe00375b41fbd5326f2da5'
+  end
+  if OS.linux? && Hardware::CPU.intel?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_amd64.tar.gz'
+    sha256 'af0eebbb44837bb61a1641cb5140eff1980b7f729a2414619071ea046bf17f92'
+  end
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm.tar.gz'
+    sha256 '50b4aa8bec48818eceb93d395a5824583494b543eec4e278f8bf98528d78935c'
+  end
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm64.tar.gz'
+    sha256 '0f389f38bdf2b28aaa8f9472a05ad0f4ca419ef9d5190c8945e24325fd6ffd47'
+  end
+
+  def install
+    bin.install 'docker-credential-up'
+  end
+
+  test do
+    system "#{bin}/docker-credential-up -v"
+  end
+end

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -15,28 +15,28 @@
 class Up < Formula
     desc "The official Upbound CLI"
     homepage "https://upbound.io"
-    version "v0.12.1"
+    version "v0.12.2"
     license "Upbound Software License"
   
     if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/darwin_amd64.tar.gz"
-      sha256 "9e3a7d0c8a906a30a3821d7667d90f67685c7efc01e9db7b3b2dd782fee52fbc"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_amd64.tar.gz"
+      sha256 "68be95d945089e67c5ab60e7a5ea3f0e4443892140a9d140c76a1a1e05f00c94"
     end
     if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/darwin_arm64.tar.gz"
-      sha256 "3d2a3c2d4bc897d948e92da2cc52bc243ef6b8217021b67c6094d30a7f2f2515"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_arm64.tar.gz"
+      sha256 "01f0d1094d9dabafe006eb2f5ba1d39e8a6598f29b88f0ad0d0ab48bf3c7bd0d"
     end
     if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/linux_amd64.tar.gz"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_amd64.tar.gz"
       sha256 "fa9817753a131f6b9f8c3be77c0c6f5b35e01925052b68ea32e64c88f0399db2"
     end
     if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/linux_arm.tar.gz"
-      sha256 "3d85466fa4e39ccb0a224690c061e69d207531cc23aa1a1696ac7880bf4b198c"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm.tar.gz"
+      sha256 "1db5fa70be70c64f81fe0ef5845a73234d503b0df97efb4bb94c0caafd300152"
     end
     if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.1/bundle/up/linux_arm64.tar.gz"
-      sha256 "abb980283399b1f5c1567f75cfc00447caf7fa7973a2c027b8bf3bdd19c58d34"
+      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm64.tar.gz"
+      sha256 "0686562379e7ce2734964d75643273983907f430cfd0e51386b76d39a9f2715a"
     end
   
     def install

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright 2022 Upbound Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,37 +15,37 @@
 # limitations under the License.
 
 class Up < Formula
-    desc "The official Upbound CLI"
-    homepage "https://upbound.io"
-    version "v0.12.2"
-    license "Upbound Software License"
-  
-    if OS.mac? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_amd64.tar.gz"
-      sha256 "68be95d945089e67c5ab60e7a5ea3f0e4443892140a9d140c76a1a1e05f00c94"
-    end
-    if OS.mac? && Hardware::CPU.arm?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_arm64.tar.gz"
-      sha256 "01f0d1094d9dabafe006eb2f5ba1d39e8a6598f29b88f0ad0d0ab48bf3c7bd0d"
-    end
-    if OS.linux? && Hardware::CPU.intel?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_amd64.tar.gz"
-      sha256 "fa9817753a131f6b9f8c3be77c0c6f5b35e01925052b68ea32e64c88f0399db2"
-    end
-    if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm.tar.gz"
-      sha256 "1db5fa70be70c64f81fe0ef5845a73234d503b0df97efb4bb94c0caafd300152"
-    end
-    if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm64.tar.gz"
-      sha256 "0686562379e7ce2734964d75643273983907f430cfd0e51386b76d39a9f2715a"
-    end
-  
-    def install
-      bin.install "up"
-    end
-  
-    test do
-      system "#{bin}/up -v"
-    end
+  desc 'The official Upbound CLI'
+  homepage 'https://upbound.io'
+  version 'v0.12.2'
+  license 'Upbound Software License'
+
+  if OS.mac? && Hardware::CPU.intel?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_amd64.tar.gz'
+    sha256 '68be95d945089e67c5ab60e7a5ea3f0e4443892140a9d140c76a1a1e05f00c94'
   end
+  if OS.mac? && Hardware::CPU.arm?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_arm64.tar.gz'
+    sha256 '01f0d1094d9dabafe006eb2f5ba1d39e8a6598f29b88f0ad0d0ab48bf3c7bd0d'
+  end
+  if OS.linux? && Hardware::CPU.intel?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_amd64.tar.gz'
+    sha256 'fa9817753a131f6b9f8c3be77c0c6f5b35e01925052b68ea32e64c88f0399db2'
+  end
+  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm.tar.gz'
+    sha256 '1db5fa70be70c64f81fe0ef5845a73234d503b0df97efb4bb94c0caafd300152'
+  end
+  if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm64.tar.gz'
+    sha256 '0686562379e7ce2734964d75643273983907f430cfd0e51386b76d39a9f2715a'
+  end
+
+  def install
+    bin.install 'up'
+  end
+
+  test do
+    system "#{bin}/up -v"
+  end
+end


### PR DESCRIPTION
Signed-off-by: Aditya Sharma <git@adi.run>
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

## Description of your changes

- [Updates docker-credential-up to v0.12.2](https://github.com/upbound/homebrew-tap/commit/e4c3bc1091efc4e56136a535447bb67a127ea269)
- [Updates up to v0.12.2](https://github.com/upbound/homebrew-tap/commit/35a5b7551ed480459daa4c63286ea0fc8e694035)
- Fix formatting errors by running `[Rubocop -A](https://github.com/upbound/homebrew-tap/commit/c24b7522738d407d05dda4e618876ec928a0fb4b)`


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

# Testing

