### PR TITLE
Update `up` and `docker-credential-up` to `v0.13.0`

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -17,28 +17,28 @@
 class DockerCredentialUp < Formula
   desc 'Upbound Docker credential helper'
   homepage 'https://upbound.io'
-  version 'v0.12.2'
+  version 'v0.13.0'
   license 'Upbound Software License'
 
   if OS.mac? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_amd64.tar.gz'
-    sha256 '856f8d9fee3267d8857aed6da29b3890a2f8a9f4e13da4d225a4bcccb490583a'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/docker-credential-up/darwin_amd64.tar.gz'
+    sha256 '079087de537edf4c9629e3c9e92ccccc9e6eaf87d507c9573af895c6e4023af9'
   end
   if OS.mac? && Hardware::CPU.arm?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/darwin_arm64.tar.gz'
-    sha256 '4c4851417c21b5ce0f90b7eceda617a0cfa17865a7fe00375b41fbd5326f2da5'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/docker-credential-up/darwin_arm64.tar.gz'
+    sha256 'c225730974304da493c056c200a88bbf268677610b00f0d0ecabd835d02c8082'
   end
   if OS.linux? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_amd64.tar.gz'
-    sha256 'af0eebbb44837bb61a1641cb5140eff1980b7f729a2414619071ea046bf17f92'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/docker-credential-up/linux_amd64.tar.gz'
+    sha256 '283b2644a8860f87a662f352220e26a98d360283f8ae82a9e88bdb2fcd82e880'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm.tar.gz'
-    sha256 '50b4aa8bec48818eceb93d395a5824583494b543eec4e278f8bf98528d78935c'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/docker-credential-up/linux_arm.tar.gz'
+    sha256 '2e6876652b24403889a4935ee628ac23ff0ff16bd5923faea8d26cd3c27d236c'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/docker-credential-up/linux_arm64.tar.gz'
-    sha256 '0f389f38bdf2b28aaa8f9472a05ad0f4ca419ef9d5190c8945e24325fd6ffd47'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/docker-credential-up/linux_arm64.tar.gz'
+    sha256 '9855b6c6911d25f1da04b12f123cd2f6c6f8306f6eec0c321495511936259a47'
   end
 
   def install

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -17,28 +17,28 @@
 class Up < Formula
   desc 'The official Upbound CLI'
   homepage 'https://upbound.io'
-  version 'v0.12.2'
+  version 'v0.13.0'
   license 'Upbound Software License'
 
   if OS.mac? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_amd64.tar.gz'
-    sha256 '68be95d945089e67c5ab60e7a5ea3f0e4443892140a9d140c76a1a1e05f00c94'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/up/darwin_amd64.tar.gz'
+    sha256 '19837ded578b121a58b89c33fec0e66cf4a82cd7b464f6d0941060397e1bf26d'
   end
   if OS.mac? && Hardware::CPU.arm?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/darwin_arm64.tar.gz'
-    sha256 '01f0d1094d9dabafe006eb2f5ba1d39e8a6598f29b88f0ad0d0ab48bf3c7bd0d'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/up/darwin_arm64.tar.gz'
+    sha256 'fddcfd2b29cb300c4e1883bc45ae5819f868190af8a4ec6bf828fe49f190060d'
   end
   if OS.linux? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_amd64.tar.gz'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/up/linux_amd64.tar.gz'
     sha256 'fa9817753a131f6b9f8c3be77c0c6f5b35e01925052b68ea32e64c88f0399db2'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm.tar.gz'
-    sha256 '1db5fa70be70c64f81fe0ef5845a73234d503b0df97efb4bb94c0caafd300152'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/up/linux_arm.tar.gz'
+    sha256 '9e8bc45bccfebb19f180e652b831280a36fbaa8403ea3320f4ddd02f4f59695e'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.12.2/bundle/up/linux_arm64.tar.gz'
-    sha256 '0686562379e7ce2734964d75643273983907f430cfd0e51386b76d39a9f2715a'
+    url 'https://cli.upbound.io/stable/v0.13.0/bundle/up/linux_arm64.tar.gz'
+    sha256 'ae8181730dffd95058666640975e0ee2621b82c04e4932ca2e371255b04f28b2'
   end
 
   def install


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the up formula to v0.13.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates the docker-credential-up formula to v0.13.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified by installing locally.