### PR TITLE
Revert "Bump forumla versions from `v0.22.1` to `v0.23.0`"

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -17,28 +17,28 @@
 class DockerCredentialUp < Formula
   desc 'Upbound Docker credential helper'
   homepage 'https://upbound.io'
-  version 'v0.23.0'
+  version 'v0.22.1'
   license 'Upbound Software License'
 
   if OS.mac? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/docker-credential-up/darwin_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/docker-credential-up/darwin_amd64.tar.gz'
+    sha256 '915ccb69b0e05b00da6c72bb2045717a265201e9a09023fca6ddc7d52d0da12a'
   end
   if OS.mac? && Hardware::CPU.arm?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/docker-credential-up/darwin_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/docker-credential-up/darwin_arm64.tar.gz'
+    sha256 '28d13d17f56bf39d063a206c57c7a5b1a82e04267c66306f74510e74a01264bb'
   end
   if OS.linux? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/docker-credential-up/linux_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/docker-credential-up/linux_amd64.tar.gz'
+    sha256 '742c4220bf0aa3f699815d8ef617fc57a2dc084a67e6e2a9175b14836d7c3c9f'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/docker-credential-up/linux_arm.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/docker-credential-up/linux_arm.tar.gz'
+    sha256 '328669c1dee6438f40d1175fcf4eeb221451e6d6836f370cb44c84181c2009dd'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/docker-credential-up/linux_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/docker-credential-up/linux_arm64.tar.gz'
+    sha256 '741e12eee322f6b5e818614e642af56f5c9f6f72c029a682064022129f3f2580'
   end
 
   def install

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -17,28 +17,28 @@
 class Up < Formula
   desc 'The official Upbound CLI'
   homepage 'https://upbound.io'
-  version 'v0.23.0'
+  version 'v0.22.1'
   license 'Upbound Software License'
 
   if OS.mac? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/up/darwin_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/up/darwin_amd64.tar.gz'
+    sha256 '8aff3375bfdb7ba6c1eed94b59e922b03d69f282c936ebcd00d62e3ca23d7baa'
   end
   if OS.mac? && Hardware::CPU.arm?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/up/darwin_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/up/darwin_arm64.tar.gz'
+    sha256 '8abaa201df8da0534bf06d3119eb1524f15f2af24860fa97f6917c5fab5c0d24'
   end
   if OS.linux? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/up/linux_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/up/linux_amd64.tar.gz'
+    sha256 'b7ae8e22e3d78f695dd128f6d722250760f8e8e6a57944bb8c7710a1d0d9adcb'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/up/linux_arm.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/up/linux_arm.tar.gz'
+    sha256 '18f588894ac03910a91e84938369e267e4b609cb82bed25bb7cda8b5355dbbbb'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.23.0/bundle/up/linux_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    url 'https://cli.upbound.io/stable/v0.22.1/bundle/up/linux_arm64.tar.gz'
+    sha256 '99133af5fe751934590ca597eebb4b037c3e96d18d2ed5f1d2648c1bb5cbf667'
   end
 
   def install


### PR DESCRIPTION
This reverts commit bc816100741103f4a0762b3929e5a1c0ced754b9.

This update included the wrong artifact hashes.