### PR TITLE
Manually update artifact hash due to mismatch

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -22,23 +22,23 @@ class DockerCredentialUp < Formula
 
   if OS.mac? && Hardware::CPU.intel?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/darwin_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.mac? && Hardware::CPU.arm?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/darwin_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.linux? && Hardware::CPU.intel?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/linux_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/linux_arm.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/linux_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
 
   def install

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -22,23 +22,23 @@ class Up < Formula
 
   if OS.mac? && Hardware::CPU.intel?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/up/darwin_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.mac? && Hardware::CPU.arm?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/up/darwin_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.linux? && Hardware::CPU.intel?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/up/linux_amd64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/up/linux_arm.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/up/linux_arm64.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
+    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
   end
 
   def install


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fix the following error on `brew upgrade` or install:

```
==> Upgrading 1 outdated package:
upbound/tap/up v0.24.2 -> v0.26.0
==> Fetching upbound/tap/up
==> Downloading https://cli.upbound.io/stable/v0.26.0/bundle/up/darwin_arm64.tar.gz
Already downloaded: /Users/phisco/Library/Caches/Homebrew/downloads/66854dc0dc8a866612ad64e18c2683036b45bba462027866cbf7a02810cdf304--darwin_arm64.tar.gz
Error: SHA256 mismatch
Expected: 1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032
  Actual: f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637
    File: /Users/phisco/Library/Caches/Homebrew/downloads/66854dc0dc8a866612ad64e18c2683036b45bba462027866cbf7a02810cdf304--darwin_arm64.tar.gz
```

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

n/a
