### PR TITLE
fix incorrect sha256

### DIFF
--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -22,23 +22,23 @@ class DockerCredentialUp < Formula
 
   if OS.mac? && Hardware::CPU.intel?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/darwin_amd64.tar.gz'
-    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
+    sha256 '9d19c4c5ffe3192b5e46a3a865fb2ade477d8d3d41361e5a3a88b2e61d6f0f6c'
   end
   if OS.mac? && Hardware::CPU.arm?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/darwin_arm64.tar.gz'
-    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
+    sha256 'c06493633c1089ea3804acf9717ef0f1a6dc6d8ddb10e496a99fde80407fc070'
   end
   if OS.linux? && Hardware::CPU.intel?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/linux_amd64.tar.gz'
-    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
+    sha256 '7425e0398e779cee0b9c98914473eb0392dacd151b4582a8ceb063e751aee801'
   end
   if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/linux_arm.tar.gz'
-    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
+    sha256 'b856a86e531c8d17247f6499727a490e6e9698f5902a10a0baeac9eb8bbec820'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up/linux_arm64.tar.gz'
-    sha256 'f44620e2d350ee03cbf131c922e6355b992a12f8cbe7f819ff37dcbc5e765637'
+    sha256 '9c0b943ed4fb346c9e83ea87536309ebbff651638f6db114c55ac3825235961d'
   end
 
   def install


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

homebrew shows SHA256 mismatch

```bash
brew upgrade docker-credential-up
```

Update sha256 for each file from https://cli.upbound.io/stable/v0.26.0/bundle/docker-credential-up

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #51

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
