### PR TITLE
Accommodate new release layout and bump to v0.41.0

### DIFF
--- a/.github/bump-formula.rb
+++ b/.github/bump-formula.rb
@@ -17,10 +17,10 @@ Dir.entries("#{REPO_ROOT}/Formula/").each do |file|
   ARCHS.each do |arch|
     formula = file.chomp('.rb')
 
-    url = "https://cli.upbound.io/stable/#{OLD_VERSION}/bundle/#{formula}/#{arch}.tar.gz"
+    url = "https://cli.upbound.io/stable/#{OLD_VERSION}/bundle/#{arch}/#{formula}.tar.gz"
     old_sha256 = `curl -sSL #{url} | sha256sum | cut -d' ' -f1`.strip
 
-    url = "https://cli.upbound.io/stable/#{NEW_VERSION}/bundle/#{formula}/#{arch}.tar.gz"
+    url = "https://cli.upbound.io/stable/#{NEW_VERSION}/bundle/#{arch}/#{formula}.tar.gz"
     new_sha256 = `curl -sSL #{url} | sha256sum | cut -d' ' -f1`.strip
 
     refs[arch] = {

--- a/.github/bump-formula.rb
+++ b/.github/bump-formula.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ARCHS = %w[darwin_amd64 darwin_arm64 linux_amd64 linux_arm linux_arm64].freeze
+ARCHS = %w[darwin_amd64 darwin_arm64 linux_amd64 linux_arm64].freeze
 
 OLD_VERSION = ARGV[0]
 NEW_VERSION = ARGV[1]

--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -17,24 +17,24 @@
 class DockerCredentialUp < Formula
   desc 'Upbound Docker credential helper'
   homepage 'https://upbound.io'
-  version 'v0.40.3'
+  version 'v0.41.0'
   license 'Upbound Software License'
 
   if OS.mac? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/darwin_amd64.tar.gz'
-    sha256 'a3b24c6c17821c0374a6a5330060c74ee2334bef5044b790b909c3414d9a08bc'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/darwin_amd64/docker-credential-up.tar.gz'
+    sha256 '575da0f8f126f5099af761aaa0bfdadd69276733250ad5d211fe31ed1cd0bb80'
   end
   if OS.mac? && Hardware::CPU.arm?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/darwin_arm64.tar.gz'
-    sha256 '46e614b4e7ab68cca0930c25c1ba9c49f84b7ca7256e1227929a4e545071c2e5'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/darwin_arm64/docker-credential-up.tar.gz'
+    sha256 '14cba4aa554be449336863d05a8b57dfd50d2df4b860dc60f89aa1852a46b4ca'
   end
   if OS.linux? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/linux_amd64.tar.gz'
-    sha256 '794f46b15989b506794fa62b9ebbd5ddc3593c2043dbd242a83221c8bb77ec79'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/linux_amd64/docker-credential-up.tar.gz'
+    sha256 'c9bc9256b7396674853051a04349b2a9ec8256d55aaac81de896f82f02cfd1cf'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/linux_arm64.tar.gz'
-    sha256 'aaf6453972a78f6ee1ebdfc93e1a87e70bbcea7a806bfee91d9cf34f1c124dc8'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/linux_arm64/docker-credential-up.tar.gz'
+    sha256 '36071d874e6e00d588ecdc611e64d397560eb9490aa4530a7e5f93dc4dfc74ce'
   end
 
   def install

--- a/Formula/docker-credential-up.rb
+++ b/Formula/docker-credential-up.rb
@@ -32,10 +32,6 @@ class DockerCredentialUp < Formula
     url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/linux_amd64.tar.gz'
     sha256 '794f46b15989b506794fa62b9ebbd5ddc3593c2043dbd242a83221c8bb77ec79'
   end
-  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/linux_arm.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
-  end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.40.3/bundle/docker-credential-up/linux_arm64.tar.gz'
     sha256 'aaf6453972a78f6ee1ebdfc93e1a87e70bbcea7a806bfee91d9cf34f1c124dc8'

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -17,24 +17,24 @@
 class Up < Formula
   desc 'The official Upbound CLI'
   homepage 'https://upbound.io'
-  version 'v0.40.3'
+  version 'v0.41.0'
   license 'Upbound Software License'
 
   if OS.mac? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/darwin_amd64.tar.gz'
-    sha256 '92dda9bc02520caf7506b1c3db51cf5f5f979e479068f7d73e9af41b093afbc3'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/darwin_amd64/up.tar.gz'
+    sha256 '92a82dae1c551933a8f16ae983ecc5d5b9e80273e47f6e614d3692a392151113'
   end
   if OS.mac? && Hardware::CPU.arm?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/darwin_arm64.tar.gz'
-    sha256 'f60c187a398de66bb6b586073a2682fd1ff7f08764b1928fdfa0545de73f2bd5'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/darwin_arm64/up.tar.gz'
+    sha256 '8c082a70384f4707316057fc9b6cf67b38cd710164beb63d0afdaa7cc0702faa'
   end
   if OS.linux? && Hardware::CPU.intel?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/linux_amd64.tar.gz'
-    sha256 'd7b0b62206dafdaa4a238893bbc848ce5708ecf917000c0cfdeaa805eb96729c'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/linux_amd64/up.tar.gz'
+    sha256 'b07f90e422eb9fa54dee8bd151f2f3f19ee8398daa8219c3f9ec57a875ebcc5a'
   end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/linux_arm64.tar.gz'
-    sha256 '5e21ad3ab5847c5f0242fb2bbadca23f65d719a01fb74582d36b2a8974ce06ab'
+    url 'https://cli.upbound.io/stable/v0.41.0/bundle/linux_arm64/up.tar.gz'
+    sha256 '647f236896f1cb7fcd13679ae5bcfac50e359ee8876a49459caf3a1a6961dc84'
   end
 
   def install

--- a/Formula/up.rb
+++ b/Formula/up.rb
@@ -32,10 +32,6 @@ class Up < Formula
     url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/linux_amd64.tar.gz'
     sha256 'd7b0b62206dafdaa4a238893bbc848ce5708ecf917000c0cfdeaa805eb96729c'
   end
-  if OS.linux? && Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-    url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/linux_arm.tar.gz'
-    sha256 '1a33651f3cdd6c743054bc528cf6c78a538f0bdb9a01d3a96587d1d9880c5032'
-  end
   if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     url 'https://cli.upbound.io/stable/v0.40.3/bundle/up/linux_arm64.tar.gz'
     sha256 '5e21ad3ab5847c5f0242fb2bbadca23f65d719a01fb74582d36b2a8974ce06ab'


### PR DESCRIPTION
### Description of your changes

We've changed the layout of bundles in the release bucket to be grouped by architecture, just like we do for binaries. Update the bump-formula script to accommodate this and bump to v0.41.0.

While we're here, remove the `linux_arm` builds. We don't actually build for `linux_arm`, and the SHA for those releases is the SHA of the 404 not found page.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Used the updated bump-formula.rb to do the bump.
